### PR TITLE
Fix weight handling bug

### DIFF
--- a/popframe/preprocessing/adjacency_calculator.py
+++ b/popframe/preprocessing/adjacency_calculator.py
@@ -122,7 +122,7 @@ class AdjacencyCalculator(BaseModel):  # pylint: disable=too-few-public-methods
                 for d_ in d.values():
                     v__ = graph_nk.addNodes(2)
                     u__ = v__ - 1
-                    w = round(d[weight], 1) if weight in d else 1
+                    w = round(d_[weight], 1) if weight in d_ else 1
                     graph_nk.addEdge(u, v, w)
                     graph_nk.addEdge(u_, u__, 0)
                     graph_nk.addEdge(v_, v__, 0)


### PR DESCRIPTION
## Summary
- fix weight selection when converting nx graph to networkit graph

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'geopandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841846cb6fc832998ee4cebee9e77a4